### PR TITLE
remove deprecated option in default config

### DIFF
--- a/mopidy_dleyna/ext.conf
+++ b/mopidy_dleyna/ext.conf
@@ -5,10 +5,6 @@ enabled = true
 # to retrieve all objects
 upnp_browse_limit = 200
 
-# maximum number of objects to retrieve by ID in a single UPnP Search
-# action (if supported by device), or 0 for no limit
-upnp_lookup_limit = 20
-
 # maximum number of objects to retrieve per UPnP Search action, or 0
 # to retrieve all objects
 upnp_search_limit = 100


### PR DESCRIPTION
This option : upnp_lookup_limit was not supported with latest version and disabled modipy-dleyna at startup of modipy

```
2016-07-15 16:08:32,905 INFO [2894:MainThread] mopidy.__main__: Disabled extensions: dleyna
2016-07-15 16:08:32,913 WARNING [2894:MainThread] mopidy.__main__: Found dleyna configuration errors, the extension has been automatically disabled:
2016-07-15 16:08:32,921 WARNING [2894:MainThread] mopidy.__main__:   dleyna/upnp_lookup_limit unknown config key.
2016-07-15 16:08:32,928 WARNING [2894:MainThread] mopidy.__main__: Please fix the extension configuration errors or disable the extensions to silence these messages.
```
